### PR TITLE
Allow Notes Fields to be Optional

### DIFF
--- a/ynab/models/category.py
+++ b/ynab/models/category.py
@@ -186,9 +186,6 @@ class Category(object):
         :param note: The note of this Category.  # noqa: E501
         :type: str
         """
-        if note is None:
-            raise ValueError("Invalid value for `note`, must not be `None`")  # noqa: E501
-
         self._note = note
 
     @property

--- a/ynab/models/month_detail.py
+++ b/ynab/models/month_detail.py
@@ -106,9 +106,6 @@ class MonthDetail(object):
         :param note: The note of this MonthDetail.  # noqa: E501
         :type: str
         """
-        if note is None:
-            raise ValueError("Invalid value for `note`, must not be `None`")  # noqa: E501
-
         self._note = note
 
     @property

--- a/ynab/models/month_summary.py
+++ b/ynab/models/month_summary.py
@@ -99,9 +99,6 @@ class MonthSummary(object):
         :param note: The note of this MonthSummary.  # noqa: E501
         :type: str
         """
-        if note is None:
-            raise ValueError("Invalid value for `note`, must not be `None`")  # noqa: E501
-
         self._note = note
 
     @property


### PR DESCRIPTION
This allows the Notes Fields to be optional for categories, month details, and month summaries.